### PR TITLE
Add NID verification with name confirmation popup

### DIFF
--- a/lib/data/db.json
+++ b/lib/data/db.json
@@ -126,7 +126,7 @@
     {
       "key": "AMOUNT_TO_PAY",
       "type": "custom-input",
-      "hideExpression": "!model.ID_NUMBER",
+      "hideExpression": "model.ID_NUMBER !== '1200280054610074'",
       "templateOptions": {
         "type": "number",
         "required": true,

--- a/lib/provider/form_state_provider.dart
+++ b/lib/provider/form_state_provider.dart
@@ -53,11 +53,30 @@ class FormStateProvider extends ChangeNotifier {
     _nidData = nid;
     _formData['lastName'] = "Faid";
     _formData['firstName'] = "JABO";
-    _formData['ammountToPay'] = "15000";
+    _formData['ammountToPay'] = 15000.0;
     _formData['nid'] = nid;
     firstName = 'John';
     lastName = 'Doe';
-    ammountToPay = 15000;
+    ammountToPay = 15000.0;
+    notifyListeners();
+  }
+
+  void updateAmount(double amount) {
+    ammountToPay = amount;
+    _formData['ammountToPay'] = amount;
+    notifyListeners();
+  }
+
+  void clearFormDataAndNID() {
+    _formData.clear();
+    _nidData = null;
+    notifyListeners();
+  }
+
+  final Map<String, String> validationErrors = {};
+
+  void clearFormData() {
+    formData.clear();
     notifyListeners();
   }
 }

--- a/lib/screens/mutuelle_application.dart
+++ b/lib/screens/mutuelle_application.dart
@@ -155,27 +155,39 @@ class _MutuelleApplicationState extends State<MutuelleApplication> {
                             const SizedBox(
                               height: 20,
                             ),
-                            MyCustomButton(
-                              text: "Pay ${formProvider.ammountToPay}",
-                              onPressed: formProvider
-                                      .hasFieldValue('ammountToPay')
-                                  ? () {
-                                      final formData = formProvider.formData;
-                                      print('Submitting form data: $formData');
+                            Consumer<FormStateProvider>(
+                              builder: (context, formProvider, child) {
+                                final amount =
+                                    formProvider.getFieldValue('ammountToPay');
+                                return MyCustomButton(
+                                  text: amount != null
+                                      ? "Pay $amount Rwf"
+                                      : "Pay",
+                                  onPressed: amount != null
+                                      ? () {
+                                          final formData =
+                                              formProvider.formData;
+                                          print(
+                                              'Submitting form data: $formData');
 
-                                      ScaffoldMessenger.of(context)
-                                          .showSnackBar(
-                                        const SnackBar(
-                                          content: Text('Payment successful!'),
-                                          backgroundColor: Colors.green,
-                                        ),
-                                      );
-                                    }
-                                  : null,
-                              backgroundColor:
-                                  formProvider.hasFieldValue('ammountToPay')
+                                          ScaffoldMessenger.of(context)
+                                              .showSnackBar(
+                                            const SnackBar(
+                                              content:
+                                                  Text('Payment successful!'),
+                                              backgroundColor: Colors.green,
+                                            ),
+                                          );
+
+                                          // clear the form data
+                                          formProvider.clearFormData();
+                                        }
+                                      : null,
+                                  backgroundColor: amount != null
                                       ? Colors.purple
                                       : Colors.grey,
+                                );
+                              },
                             ),
                           ],
                         );


### PR DESCRIPTION
- Implement NID validation to ensure it is 16 digits and matches a specific ID.
- Add popup dialog to prompt user to enter their name when NID is validated.
- Validate entered name to confirm it matches faid; show error message if incorrect.
- Update form state to handle NID and name validation, providing feedback to user.

This feature improves user verification by adding an additional layer of security.