### PR TITLE
refactor(pdf-viewer): Simplify navigation to full view mode

### DIFF
--- a/lib/components/pdf_view.dart
+++ b/lib/components/pdf_view.dart
@@ -11,12 +11,10 @@ class PdfViewTerence extends StatefulWidget {
 }
 
 class _PdfViewTerenceState extends State<PdfViewTerence> {
-  bool _isFullView = false;
-
   @override
   Widget build(BuildContext context) {
     return Scaffold(
-      appBar: CustomAppBar(
+      appBar: const CustomAppBar(
         title: "PDF Viewer",
       ),
       body: SingleChildScrollView(
@@ -29,86 +27,112 @@ class _PdfViewTerenceState extends State<PdfViewTerence> {
           child: Column(
             children: [
               GestureDetector(
-                onTap: _isFullView
-                    ? () {
-                        setState(() {
-                          _isFullView = false;
-                        });
-                      }
-                    : null,
+                behavior: HitTestBehavior.opaque,
+                onTap: () {
+                  Navigator.push(
+                    context,
+                    MaterialPageRoute(
+                      builder: (context) => Scaffold(
+                        appBar: AppBar(
+                          title: const Text('PDF Viewer'),
+                          leading: IconButton(
+                            icon: const Icon(Icons.arrow_back),
+                            onPressed: () => Navigator.pop(context),
+                          ),
+                        ),
+                        body: SfPdfViewer.asset(
+                          "assets/images/cert.pdf",
+                          enableDoubleTapZooming: true,
+                        ),
+                      ),
+                    ),
+                  );
+                },
                 child: ClipRRect(
                   borderRadius: const BorderRadius.only(
                     topLeft: Radius.circular(25),
                     topRight: Radius.circular(25),
                   ),
                   child: SizedBox(
-                    height: _isFullView
-                        ? MediaQuery.of(context).size.height - 100
-                        : 300,
+                    height: 300,
                     child: SfPdfViewer.asset(
                       "assets/images/cert.pdf",
-                      enableDoubleTapZooming: _isFullView,
-                      initialZoomLevel: _isFullView ? 1 : 0.75,
+                      enableDoubleTapZooming: false,
+                      initialZoomLevel: 0.75,
                     ),
                   ),
                 ),
               ),
-              if (!_isFullView)
-                Container(
-                  decoration: BoxDecoration(
-                    border: Border(
-                      top: BorderSide(
-                        color: Colors.grey.shade200,
-                        width: 1,
-                      ),
-                    ),
-                  ),
-                  child: TextButton(
-                    onPressed: () {
-                      setState(() {
-                        _isFullView = true;
-                      });
-                    },
-                    style: TextButton.styleFrom(
-                      minimumSize: const Size(double.infinity, 50),
-                      padding: const EdgeInsets.symmetric(
-                          vertical: 12, horizontal: 16),
-                      shape: const RoundedRectangleBorder(
-                        borderRadius: BorderRadius.only(
-                          bottomLeft: Radius.circular(25),
-                          bottomRight: Radius.circular(25),
-                        ),
-                      ),
-                    ),
-                    child: Row(
-                      children: [
-                        Container(
-                          width: 40,
-                          height: 40,
-                          decoration: BoxDecoration(
-                            color: Colors.purple.shade100,
-                            shape: BoxShape.circle,
-                          ),
-                          child: const Icon(
-                            FontAwesomeIcons.filePdf,
-                            color: Colors.purple,
-                          ),
-                        ),
-                        const SizedBox(width: 12),
-                        const Expanded(
-                          child: Text(
-                            "Birth certificate/01/2024.pdf",
-                            style: TextStyle(
-                              fontSize: 16,
-                              fontWeight: FontWeight.w400,
-                              color: Colors.black87,
-                            ),
-                          ),
-                        ),
-                      ],
+              Container(
+                decoration: BoxDecoration(
+                  border: Border(
+                    top: BorderSide(
+                      color: Colors.grey.shade200,
+                      width: 1,
                     ),
                   ),
                 ),
+                child: TextButton(
+                  onPressed: () {
+                    Navigator.push(
+                      context,
+                      MaterialPageRoute(
+                        builder: (context) => Scaffold(
+                          appBar: AppBar(
+                            title: const Text('PDF Viewer'),
+                            leading: IconButton(
+                              icon: const Icon(Icons.arrow_back),
+                              onPressed: () => Navigator.pop(context),
+                            ),
+                          ),
+                          body: SfPdfViewer.asset(
+                            "assets/images/cert.pdf",
+                            enableDoubleTapZooming: true,
+                          ),
+                        ),
+                      ),
+                    );
+                  },
+                  style: TextButton.styleFrom(
+                    minimumSize: const Size(double.infinity, 50),
+                    padding: const EdgeInsets.symmetric(
+                        vertical: 12, horizontal: 16),
+                    shape: const RoundedRectangleBorder(
+                      borderRadius: BorderRadius.only(
+                        bottomLeft: Radius.circular(25),
+                        bottomRight: Radius.circular(25),
+                      ),
+                    ),
+                  ),
+                  child: Row(
+                    children: [
+                      Container(
+                        width: 40,
+                        height: 40,
+                        decoration: BoxDecoration(
+                          color: Colors.purple.shade100,
+                          shape: BoxShape.circle,
+                        ),
+                        child: const Icon(
+                          FontAwesomeIcons.filePdf,
+                          color: Colors.purple,
+                        ),
+                      ),
+                      const SizedBox(width: 12),
+                      const Expanded(
+                        child: Text(
+                          "Birth certificate/01/2024.pdf",
+                          style: TextStyle(
+                            fontSize: 16,
+                            fontWeight: FontWeight.w400,
+                            color: Colors.black87,
+                          ),
+                        ),
+                      ),
+                    ],
+                  ),
+                ),
+              ),
             ],
           ),
         ),


### PR DESCRIPTION
- Remove _isFullView state and related toggle logic
- Standardize PDF preview to fixed 300px height
- Implement consistent navigation pattern for both preview and button
- Disable preview zooming for better UX
- Maintain card-based design with rounded corners

This change simplifies the component's behavior by always opening the PDF in a new view, providing a more predictable user experience and cleaner codebase.