### PR TITLE
refactor(pdf-viewer): Convert to reusable component with improved layout

### DIFF
--- a/lib/components/pdf_view.dart
+++ b/lib/components/pdf_view.dart
@@ -3,138 +3,138 @@ import 'package:flutter/material.dart';
 import 'package:font_awesome_flutter/font_awesome_flutter.dart';
 import 'package:syncfusion_flutter_pdfviewer/pdfviewer.dart';
 
-class PdfViewTerence extends StatefulWidget {
-  const PdfViewTerence({super.key});
+class PdfViewCard extends StatelessWidget {
+  final String pdfPath;
+  final String fileName;
+  final double previewHeight;
+  final String? viewerTitle;
+  final Color? iconColor;
+  final Color? iconBackgroundColor;
+  final double borderRadius;
+  final double elevation;
 
-  @override
-  State<PdfViewTerence> createState() => _PdfViewTerenceState();
-}
+  const PdfViewCard({
+    super.key,
+    required this.pdfPath,
+    required this.fileName,
+    this.previewHeight = 300,
+    this.viewerTitle = 'PDF Viewer',
+    this.iconColor = Colors.purple,
+    this.iconBackgroundColor,
+    this.borderRadius = 25,
+    this.elevation = 2,
+  });
 
-class _PdfViewTerenceState extends State<PdfViewTerence> {
+  void _openPdfViewer(BuildContext context) {
+    Navigator.push(
+      context,
+      MaterialPageRoute(
+        builder: (context) => Scaffold(
+          appBar: AppBar(
+            title: Text(viewerTitle!),
+            leading: IconButton(
+              icon: const Icon(Icons.arrow_back),
+              onPressed: () => Navigator.pop(context),
+            ),
+          ),
+          body: SfPdfViewer.asset(
+            pdfPath,
+            enableDoubleTapZooming: true,
+          ),
+        ),
+      ),
+    );
+  }
+
   @override
   Widget build(BuildContext context) {
-    return Scaffold(
-      appBar: const CustomAppBar(
-        title: "PDF Viewer",
-      ),
-      body: SingleChildScrollView(
-        padding: const EdgeInsets.all(16),
-        child: Card(
-          elevation: 2,
-          shape: RoundedRectangleBorder(
-            borderRadius: BorderRadius.circular(25),
-          ),
-          child: Column(
-            children: [
-              GestureDetector(
-                behavior: HitTestBehavior.opaque,
-                onTap: () {
-                  Navigator.push(
-                    context,
-                    MaterialPageRoute(
-                      builder: (context) => Scaffold(
-                        appBar: AppBar(
-                          title: const Text('PDF Viewer'),
-                          leading: IconButton(
-                            icon: const Icon(Icons.arrow_back),
-                            onPressed: () => Navigator.pop(context),
-                          ),
-                        ),
-                        body: SfPdfViewer.asset(
-                          "assets/images/cert.pdf",
-                          enableDoubleTapZooming: true,
-                        ),
-                      ),
-                    ),
-                  );
-                },
-                child: ClipRRect(
-                  borderRadius: const BorderRadius.only(
-                    topLeft: Radius.circular(25),
-                    topRight: Radius.circular(25),
-                  ),
-                  child: SizedBox(
-                    height: 300,
-                    child: SfPdfViewer.asset(
-                      "assets/images/cert.pdf",
-                      enableDoubleTapZooming: false,
-                      initialZoomLevel: 0.75,
-                    ),
+    return Container(
+      padding: const EdgeInsets.all(16),
+      child: Container(
+        decoration: BoxDecoration(
+          color: Colors.white,
+          borderRadius: BorderRadius.circular(borderRadius),
+          boxShadow: [
+            BoxShadow(
+              color: Colors.black.withOpacity(0.05),
+              blurRadius: 10,
+              offset: const Offset(0, 2),
+            ),
+          ],
+        ),
+        child: Column(
+          children: [
+            GestureDetector(
+              behavior: HitTestBehavior.opaque,
+              onTap: () => _openPdfViewer(context),
+              child: ClipRRect(
+                borderRadius: BorderRadius.only(
+                  topLeft: Radius.circular(borderRadius),
+                  topRight: Radius.circular(borderRadius),
+                ),
+                child: SizedBox(
+                  height: previewHeight,
+                  child: SfPdfViewer.asset(
+                    pdfPath,
+                    enableDoubleTapZooming: false,
+                    initialZoomLevel: 0.75,
                   ),
                 ),
               ),
-              Container(
-                decoration: BoxDecoration(
-                  border: Border(
-                    top: BorderSide(
-                      color: Colors.grey.shade200,
-                      width: 1,
-                    ),
-                  ),
-                ),
-                child: TextButton(
-                  onPressed: () {
-                    Navigator.push(
-                      context,
-                      MaterialPageRoute(
-                        builder: (context) => Scaffold(
-                          appBar: AppBar(
-                            title: const Text('PDF Viewer'),
-                            leading: IconButton(
-                              icon: const Icon(Icons.arrow_back),
-                              onPressed: () => Navigator.pop(context),
-                            ),
-                          ),
-                          body: SfPdfViewer.asset(
-                            "assets/images/cert.pdf",
-                            enableDoubleTapZooming: true,
-                          ),
-                        ),
-                      ),
-                    );
-                  },
-                  style: TextButton.styleFrom(
-                    minimumSize: const Size(double.infinity, 50),
-                    padding: const EdgeInsets.symmetric(
-                        vertical: 12, horizontal: 16),
-                    shape: const RoundedRectangleBorder(
-                      borderRadius: BorderRadius.only(
-                        bottomLeft: Radius.circular(25),
-                        bottomRight: Radius.circular(25),
-                      ),
-                    ),
-                  ),
-                  child: Row(
-                    children: [
-                      Container(
-                        width: 40,
-                        height: 40,
-                        decoration: BoxDecoration(
-                          color: Colors.purple.shade100,
-                          shape: BoxShape.circle,
-                        ),
-                        child: const Icon(
-                          FontAwesomeIcons.filePdf,
-                          color: Colors.purple,
-                        ),
-                      ),
-                      const SizedBox(width: 12),
-                      const Expanded(
-                        child: Text(
-                          "Birth certificate/01/2024.pdf",
-                          style: TextStyle(
-                            fontSize: 16,
-                            fontWeight: FontWeight.w400,
-                            color: Colors.black87,
-                          ),
-                        ),
-                      ),
-                    ],
+            ),
+            Container(
+              decoration: BoxDecoration(
+                border: Border(
+                  top: BorderSide(
+                    color: Colors.grey.shade200,
+                    width: 1,
                   ),
                 ),
               ),
-            ],
-          ),
+              child: TextButton(
+                onPressed: () => _openPdfViewer(context),
+                style: TextButton.styleFrom(
+                  minimumSize: const Size(double.infinity, 50),
+                  padding:
+                      const EdgeInsets.symmetric(vertical: 12, horizontal: 16),
+                  shape: RoundedRectangleBorder(
+                    borderRadius: BorderRadius.only(
+                      bottomLeft: Radius.circular(borderRadius),
+                      bottomRight: Radius.circular(borderRadius),
+                    ),
+                  ),
+                ),
+                child: Row(
+                  children: [
+                    Container(
+                      width: 40,
+                      height: 40,
+                      decoration: BoxDecoration(
+                        color:
+                            iconBackgroundColor ?? iconColor?.withOpacity(0.1),
+                        shape: BoxShape.circle,
+                      ),
+                      child: Icon(
+                        FontAwesomeIcons.filePdf,
+                        color: iconColor,
+                      ),
+                    ),
+                    const SizedBox(width: 12),
+                    Expanded(
+                      child: Text(
+                        fileName,
+                        style: const TextStyle(
+                          fontSize: 16,
+                          fontWeight: FontWeight.w400,
+                          color: Colors.black87,
+                        ),
+                      ),
+                    ),
+                  ],
+                ),
+              ),
+            ),
+          ],
         ),
       ),
     );

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -3,6 +3,7 @@ import 'package:dynamic_form_generator/provider/certificates_provider.dart';
 import 'package:dynamic_form_generator/provider/updates_provider.dart';
 import 'package:dynamic_form_generator/screens/certificates_screen.dart';
 import 'package:dynamic_form_generator/screens/form_builder_demo.dart';
+import 'package:dynamic_form_generator/screens/main_screen.dart';
 import 'package:dynamic_form_generator/screens/make_payments.dart';
 import 'package:dynamic_form_generator/screens/mutuelle_application.dart';
 import 'package:dynamic_form_generator/screens/payment_methods.dart';
@@ -41,7 +42,7 @@ class MyApp extends StatelessWidget {
           contentPadding: EdgeInsets.symmetric(horizontal: 16, vertical: 12),
         ),
       ),
-      home: const PdfViewTerence(),
+      home: const MainScreen(),
       routes: {
         "/ ": (context) => const FormBuilderDemo(),
         "/mutuelle": (context) => const MutuelleApplication(),

--- a/lib/provider/certificates_provider.dart
+++ b/lib/provider/certificates_provider.dart
@@ -7,7 +7,7 @@ class CertificatesProvider extends ChangeNotifier {
       title: "Birth Certificate",
       imagePath: "assets/images/birthcert.png",
       description: "Click here to view it",
-      pdfPath: "assets/pdf/birthcert.pdf",
+      pdfPath: "assets/images/cert.pdf",
     ),
     Certificate(
       title: "Marriage Certificate",

--- a/lib/screens/certificates_screen.dart
+++ b/lib/screens/certificates_screen.dart
@@ -1,7 +1,9 @@
 import 'package:dynamic_form_generator/components/app_bar.dart';
 import 'package:dynamic_form_generator/components/certiificate_holder.dart';
 import 'package:dynamic_form_generator/components/list_of_certificates.dart';
+import 'package:dynamic_form_generator/components/pdf_view.dart';
 import 'package:dynamic_form_generator/provider/certificates_provider.dart';
+import 'package:dynamic_form_generator/screens/view_certificates.dart';
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
 
@@ -40,9 +42,9 @@ class _CertificatesScreenState extends State<CertificatesScreen> {
             Navigator.push(
               context,
               MaterialPageRoute(
-                builder: (context) => CertificateHolder(
+                builder: (context) => ViewCertificates(
                   pdfPath: certificates[index].pdfPath,
-                  pdfName: certificates[index].title,
+                  fileName: certificates[index].title,
                 ),
               ),
             );

--- a/lib/screens/view_certificates.dart
+++ b/lib/screens/view_certificates.dart
@@ -1,0 +1,25 @@
+import 'package:dynamic_form_generator/components/app_bar.dart';
+import 'package:dynamic_form_generator/components/pdf_view.dart';
+import 'package:flutter/material.dart';
+
+class ViewCertificates extends StatelessWidget {
+  final String fileName;
+  final String pdfPath;
+  const ViewCertificates(
+      {super.key, required this.fileName, required this.pdfPath});
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: CustomAppBar(
+        title: fileName,
+      ),
+      body: SingleChildScrollView(
+        child: PdfViewCard(
+          fileName: fileName,
+          pdfPath: pdfPath,
+        ),
+      ),
+    );
+  }
+}


### PR DESCRIPTION
- Create PdfViewCard as a standalone reusable component
- Add customizable parameters (colors, sizes, titles)
- Implement proper scrolling behavior in ViewCertificates
- Add proper white container styling with consistent padding
- Extract PDF viewer navigation logic into separate method

BREAKING CHANGE: PdfViewTerence is now PdfViewCard with a new API. Previous implementations will need to be updated to use the new component structure.