### PR TITLE
feat: implement smooth transitions between onboarding screens

### DIFF
--- a/lib/components/language_select.dart
+++ b/lib/components/language_select.dart
@@ -1,0 +1,92 @@
+import 'package:dynamic_form_generator/components/primary_button.dart';
+import 'package:flutter/material.dart';
+
+class LanguageSelect extends StatefulWidget {
+  final Function(String) onLanguageSelected;
+
+  /// route to navigate to after language is selected
+  final String routeToNavigate;
+
+  const LanguageSelect({
+    super.key,
+    required this.onLanguageSelected,
+    required this.routeToNavigate,
+  });
+
+  @override
+  State<LanguageSelect> createState() => _LanguageSelectState();
+}
+
+class _LanguageSelectState extends State<LanguageSelect> {
+  String selectedLanguage = 'English'; // Default selection
+
+  Widget _buildLanguageOption(String language) {
+    bool isSelected = selectedLanguage == language;
+    return GestureDetector(
+      onTap: () {
+        setState(() {
+          selectedLanguage = language;
+          print('Selected Language: $language'); // Print on selection
+          widget.onLanguageSelected(language); // Callback to parent
+        });
+      },
+      child: Container(
+        padding: const EdgeInsets.all(12),
+        decoration: BoxDecoration(
+          border: Border.all(
+            color: isSelected ? Colors.purple : Colors.grey.shade300,
+            width: 1,
+          ),
+          borderRadius: BorderRadius.circular(14),
+        ),
+        child: Text(
+          language,
+          style: const TextStyle(
+            fontSize: 16,
+            color: Colors.black,
+          ),
+        ),
+      ),
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      width: MediaQuery.of(context).size.width * 0.9,
+      height: 396,
+      padding: const EdgeInsets.all(20),
+      decoration: BoxDecoration(
+        color: Colors.white,
+        borderRadius: BorderRadius.circular(16),
+      ),
+      child: Column(
+        mainAxisSize: MainAxisSize.min,
+        crossAxisAlignment: CrossAxisAlignment.stretch,
+        children: [
+          const Text(
+            'Choose Language',
+            style: TextStyle(
+              fontSize: 20,
+              fontWeight: FontWeight.bold,
+              color: Colors.black,
+            ),
+          ),
+          const SizedBox(height: 16),
+          _buildLanguageOption('English'),
+          const SizedBox(height: 8),
+          _buildLanguageOption('Français'),
+          const SizedBox(height: 8),
+          _buildLanguageOption('Kinyarwanda'),
+          const SizedBox(height: 16),
+          PrimaryButton(
+            text: "Continue",
+            onPressed: () {
+              Navigator.pushNamed(context, widget.routeToNavigate);
+            },
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -2,15 +2,13 @@ import 'package:dynamic_form_generator/provider/certificates_provider.dart';
 import 'package:dynamic_form_generator/provider/updates_provider.dart';
 import 'package:dynamic_form_generator/screens/certificates_screen.dart';
 import 'package:dynamic_form_generator/screens/form_builder_demo.dart';
-
+import 'package:dynamic_form_generator/screens/initial_screen.dart';
 import 'package:dynamic_form_generator/screens/make_payments.dart';
 import 'package:dynamic_form_generator/screens/mutuelle_application.dart';
-import 'package:dynamic_form_generator/components/onboarding_screen.dart';
 import 'package:dynamic_form_generator/screens/on_boarding_screen_one.dart';
 import 'package:dynamic_form_generator/screens/on_boarding_screen_two.dart';
 import 'package:dynamic_form_generator/screens/payment_methods.dart';
 import 'package:dynamic_form_generator/screens/user_payments.dart';
-import 'package:dynamic_form_generator/screens/vehicle_ownership.dart';
 import 'package:flutter/material.dart';
 import 'package:dynamic_form_generator/provider/form_state_provider.dart';
 import 'package:provider/provider.dart';
@@ -45,7 +43,7 @@ class MyApp extends StatelessWidget {
           contentPadding: EdgeInsets.symmetric(horizontal: 16, vertical: 12),
         ),
       ),
-      home: const OnBoardingScreenOne(),
+      home: const InitialScreen(),
       routes: {
         "/ ": (context) => const FormBuilderDemo(),
         "/mutuelle": (context) => const MutuelleApplication(),

--- a/lib/screens/initial_screen.dart
+++ b/lib/screens/initial_screen.dart
@@ -1,0 +1,55 @@
+import 'package:dynamic_form_generator/screens/onboarding_screen.dart';
+import 'package:flutter/material.dart';
+import 'package:dynamic_form_generator/components/language_select.dart';
+
+class InitialScreen extends StatefulWidget {
+  const InitialScreen({super.key});
+
+  @override
+  State<InitialScreen> createState() => _InitialScreenState();
+}
+
+class _InitialScreenState extends State<InitialScreen> {
+  String currentLanguage = 'English';
+
+  void handleLanguageSelection(String language) {
+    setState(() {
+      currentLanguage = language;
+      print('Language updated in InitialScreen: $language');
+    });
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      body: Stack(
+        children: [
+          OnboardingScreen(
+            imagePath: "assets/images/onboard1.png",
+            chatBubbleMessage: "🎉 Your birth certificate is available",
+            title: "Access Your Essential Certificates Easily",
+            subtitle:
+                "Get your birth, marriage, and other certificates from the comfort of your home. Just quick applications with a few taps.",
+            buttonText: "Next",
+            skipButtonText: "Skip",
+            onButtonPressed: () {},
+            onSkipPressed: () {},
+            isActive: true,
+          ),
+          Container(
+            color: Colors.black.withOpacity(0.5),
+            child: Center(
+              child: Padding(
+                padding: const EdgeInsets.symmetric(horizontal: 24),
+                child: LanguageSelect(
+                  onLanguageSelected: handleLanguageSelection,
+                  routeToNavigate: "/onboarding1",
+                ),
+              ),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/screens/on_boarding_screen_one.dart
+++ b/lib/screens/on_boarding_screen_one.dart
@@ -1,3 +1,4 @@
+import 'package:dynamic_form_generator/screens/on_boarding_screen_two.dart';
 import 'package:dynamic_form_generator/screens/onboarding_screen.dart';
 import 'package:flutter/material.dart';
 
@@ -15,7 +16,21 @@ class OnBoardingScreenOne extends StatelessWidget {
       buttonText: "Next",
       skipButtonText: "Skip",
       onButtonPressed: () {
-        Navigator.pushNamed(context, "/onboarding2");
+        Navigator.push(
+          context,
+          PageRouteBuilder(
+            pageBuilder: (context, animation, secondaryAnimation) =>
+                const OnBoardingScreenTwo(),
+            transitionsBuilder:
+                (context, animation, secondaryAnimation, child) {
+              return FadeTransition(
+                opacity: animation,
+                child: child,
+              );
+            },
+            transitionDuration: const Duration(milliseconds: 300),
+          ),
+        );
       },
       onSkipPressed: () {},
       isActive: true,

--- a/lib/screens/on_boarding_screen_two.dart
+++ b/lib/screens/on_boarding_screen_two.dart
@@ -1,4 +1,5 @@
 import 'package:dynamic_form_generator/components/onboarding_screen.dart';
+import 'package:dynamic_form_generator/screens/on_boarding_screen_one.dart';
 import 'package:flutter/material.dart';
 
 class OnBoardingScreenTwo extends StatelessWidget {
@@ -17,7 +18,21 @@ class OnBoardingScreenTwo extends StatelessWidget {
       skipButtonText: "Back",
       onButtonPressed: () {},
       onSkipPressed: () {
-        Navigator.pushNamed(context, "/onboarding1");
+        Navigator.push(
+          context,
+          PageRouteBuilder(
+            pageBuilder: (context, animation, secondaryAnimation) =>
+                const OnBoardingScreenOne(),
+            transitionsBuilder:
+                (context, animation, secondaryAnimation, child) {
+              return FadeTransition(
+                opacity: animation,
+                child: child,
+              );
+            },
+            transitionDuration: const Duration(milliseconds: 300),
+          ),
+        );
       },
       isActive: false,
     );


### PR DESCRIPTION
- Add fade transitions for seamless navigation between onboarding screens
- Implement cross-fade effect for next and back navigation
- Set consistent 300ms transition duration
- Keep language selector modal centered on initial screen

This enhances the user experience by making screen transitions feel more natural and cohesive.